### PR TITLE
update ffmpeg to 4.4.2

### DIFF
--- a/builders/ffmpeg.cmake
+++ b/builders/ffmpeg.cmake
@@ -40,9 +40,8 @@ else()
 		set(EP_ffmpeg_PATCH_OPTIONS "--binary")
 	endif()
 
-	lcb_git_repository("https://gitlab.linphone.org/BC/public/external/ffmpeg.git")
-	lcb_git_tag_latest("bc")
-	lcb_git_tag("51aa587f7ddac63c831d73eb360e246765a2675f")
+	lcb_git_repository("https://git.ffmpeg.org/ffmpeg.git")
+	lcb_git_tag_latest("4.4.2")
 	lcb_external_source_paths("externals/ffmpeg" "external/ffmpeg")
 	lcb_may_be_found_on_system(YES)
 	lcb_ignore_warnings(YES)
@@ -53,7 +52,6 @@ else()
 		"--disable-bzlib"
 		"--disable-ffplay"
 		"--disable-ffprobe"
-		"--disable-ffserver"
 		"--disable-avdevice"
 		"--disable-avfilter"
 		"--disable-network"
@@ -62,7 +60,6 @@ else()
 		"--enable-decoder=mjpeg"
 		"--enable-encoder=mjpeg"
 		# Disable video acceleration support for compatibility with older Mac OS X versions (vda, vaapi, vdpau).
-		"--disable-vda"
 		"--disable-vaapi"
 		"--disable-vdpau"
 		"--ar=\$AR"

--- a/builders/ffmpeg/postinstall.cmake
+++ b/builders/ffmpeg/postinstall.cmake
@@ -24,39 +24,45 @@ if(WIN32)
 	set(FFMPEG_ARCH ${CMAKE_CXX_COMPILER_ARCHITECTURE_ID})
 	string(TOUPPER ${FFMPEG_ARCH} FFMPEG_ARCH)
 	message(STATUS "Linking FFMPEG to ${FFMPEG_ARCH} arch")
-	
-	if(EXISTS ${INSTALL_PREFIX}/lib/avcodec-53.def)
-		execute_process(COMMAND "lib" "/def:${INSTALL_PREFIX}/lib/avcodec-53.def" "/out:${INSTALL_PREFIX}/lib/avcodec.lib" "/machine:${FFMPEG_ARCH}")
+
+	file(GLOB AVCODEC_DEF "${INSTALL_PREFIX}/lib/avcodec-*.def")
+	if(AVCODEC_DEF)
+		execute_process(COMMAND "lib" "/def:${AVCODEC_DEF}" "/out:${INSTALL_PREFIX}/lib/avcodec.lib" "/machine:${FFMPEG_ARCH}")
 	endif()
-	if(EXISTS ${INSTALL_PREFIX}/lib/avutil-51.def)
-		execute_process(COMMAND "lib" "/def:${INSTALL_PREFIX}/lib/avutil-51.def" "/out:${INSTALL_PREFIX}/lib/avutil.lib" "/machine:${FFMPEG_ARCH}")
+	file(GLOB AVUTIL_DEF "${INSTALL_PREFIX}/lib/avutil-*.def")
+	if(AVUTIL_DEF)
+		execute_process(COMMAND "lib" "/def:${AVUTIL_DEF}" "/out:${INSTALL_PREFIX}/lib/avutil.lib" "/machine:${FFMPEG_ARCH}")
 	endif()
-	if(EXISTS ${INSTALL_PREFIX}/lib/swresample-0.def)
-		execute_process(COMMAND "lib" "/def:${INSTALL_PREFIX}/lib/swresample-0.def" "/out:${INSTALL_PREFIX}/lib/swresample.lib" "/machine:${FFMPEG_ARCH}")
+	file(GLOB SWRESAMPLE_DEF "${INSTALL_PREFIX}/lib/swresample-*.def")
+	if(SWRESAMPLE_DEF)
+		execute_process(COMMAND "lib" "/def:${SWRESAMPLE_DEF}" "/out:${INSTALL_PREFIX}/lib/swresample.lib" "/machine:${FFMPEG_ARCH}")
 	endif()
-	if(EXISTS ${INSTALL_PREFIX}/lib/swscale-2.def)
-		execute_process(COMMAND "lib" "/def:${INSTALL_PREFIX}/lib/swscale-2.def" "/out:${INSTALL_PREFIX}/lib/swscale.lib" "/machine:${FFMPEG_ARCH}")
+	file(GLOB SWSCALE_DEF "${INSTALL_PREFIX}/lib/swscale-*.def")
+	if(SWSCALE_DEF)
+		execute_process(COMMAND "lib" "/def:${SWSCALE_DEF}" "/out:${INSTALL_PREFIX}/lib/swscale.lib" "/machine:${FFMPEG_ARCH}")
 	endif()
 endif()
 
+file(GLOB AVUTIL_DYLIB RELATIVE "${INSTALL_PREFIX}/lib" "${INSTALL_PREFIX}/lib/libavutil.*.*.*.dylib")
+file(GLOB AVCODEC_DYLIB RELATIVE "${INSTALL_PREFIX}/lib" "${INSTALL_PREFIX}/lib/libavcodec.*.*.*.dylib")
+file(GLOB SWRESAMPLE_DYLIB RELATIVE "${INSTALL_PREFIX}/lib" "${INSTALL_PREFIX}/lib/libswresample.*.*.*.dylib")
+file(GLOB SWSCALE_DYLIB RELATIVE "${INSTALL_PREFIX}/lib" "${INSTALL_PREFIX}/lib/libswscale.*.*.*.dylib")
+
 if(APPLE AND NOT IOS)
+	execute_process(COMMAND install_name_tool -id @rpath/${AVUTIL_DYLIB} ${INSTALL_PREFIX}/lib/${AVUTIL_DYLIB})
 	execute_process(COMMAND install_name_tool
-		-id @rpath/libavcodec.53.61.100.dylib
-		-change ${INSTALL_PREFIX}/lib/libavutil.51.35.100.dylib @rpath/libavutil.51.35.100.dylib
-		${INSTALL_PREFIX}/lib/libavcodec.53.61.100.dylib
+		-id @rpath/${AVCODEC_DYLIB}
+		-change ${INSTALL_PREFIX}/lib/${AVUTIL_DYLIB} @rpath/${AVUTIL_DYLIB}
+		${INSTALL_PREFIX}/lib/${AVCODEC_DYLIB}
 	)
 	execute_process(COMMAND install_name_tool
-		-id @rpath/libavutil.51.35.100.dylib
-		${INSTALL_PREFIX}/lib/libavutil.51.35.100.dylib
+		-id @rpath/${SWRESAMPLE_DYLIB}
+		-change ${INSTALL_PREFIX}/lib/${AVUTIL_DYLIB} @rpath/${AVUTIL_DYLIB}
+		${INSTALL_PREFIX}/lib/${SWRESAMPLE_DYLIB}
 	)
 	execute_process(COMMAND install_name_tool
-		-id @rpath/libswresample.0.6.100.dylib
-		-change ${INSTALL_PREFIX}/lib/libavutil.51.35.100.dylib @rpath/libavutil.51.35.100.dylib
-		${INSTALL_PREFIX}/lib/libswresample.0.6.100.dylib
-	)
-	execute_process(COMMAND install_name_tool
-		-id @rpath/libswscale.2.1.100.dylib
-		-change ${INSTALL_PREFIX}/lib/libavutil.51.35.100.dylib @rpath/libavutil.51.35.100.dylib
-		${INSTALL_PREFIX}/lib/libswscale.2.1.100.dylib
+		-id @rpath/${SWSCALE_DYLIB}
+		-change ${INSTALL_PREFIX}/lib/${AVUTIL_DYLIB} @rpath/${AVUTIL_DYLIB}
+		${INSTALL_PREFIX}/lib/${SWSCALE_DYLIB}
 	)
 endif()

--- a/builders/ffmpegandroid/CMakeLists.txt
+++ b/builders/ffmpegandroid/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################################################################
-# ffmpegandroid.cmake
+# CMakeLists.txt
 # Copyright (C) 2016  Belledonne Communications, Grenoble France
 #
 ############################################################################
@@ -20,5 +20,26 @@
 #
 ############################################################################
 
-lcb_external_source_paths("cmake-builder/builders/ffmpegandroid")
-lcb_dependencies("ffmpeg")
+cmake_minimum_required(VERSION 3.0)
+project(ffmpegandroid LANGUAGES C)
+
+include(GNUInstallDirs)
+
+
+find_library(AVCODEC_LIBRARY avcodec)
+find_library(AVUTIL_LIBRARY avutil)
+find_library(SWRESAMPLE_LIBRARY swresample)
+find_library(SWSCALE_LIBRARY swscale)
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/dummy.c" "")
+
+add_library(ffmpeg-linphone SHARED "${CMAKE_CURRENT_BINARY_DIR}/dummy.c")
+target_link_libraries(ffmpeg-linphone LINK_PRIVATE "m" "-Wl,-whole-archive" ${AVCODEC_LIBRARY} ${AVUTIL_LIBRARY} ${SWRESAMPLE_LIBRARY} ${SWSCALE_LIBRARY} "-Wl,-no-whole-archive")
+set_target_properties(ffmpeg-linphone PROPERTIES LINKER_LANGUAGE C)
+
+install(TARGETS ffmpeg-linphone
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)

--- a/builders/msx264.cmake
+++ b/builders/msx264.cmake
@@ -21,8 +21,7 @@
 ############################################################################
 
 lcb_git_repository("https://gitlab.linphone.org/BC/public/msx264.git")
-lcb_git_tag_latest("master")
-lcb_git_tag("3a9b5a9ff79ea45b9f8f03d03d4a4a9213dc2c5d")
+lcb_git_tag_latest("d61977cbe453869cec28d32b71fe25c2cd965dcf")
 lcb_external_source_paths("msx264")
 lcb_groupable(YES)
 lcb_plugin(YES)

--- a/builders/x264.cmake
+++ b/builders/x264.cmake
@@ -20,8 +20,7 @@
 #
 ############################################################################
 
-lcb_git_repository("git://git.videolan.org/x264.git")
-lcb_git_tag("adc99d17d8c1fbc164fae8319b40d7c45f30314e")
+lcb_git_repository("https://code.videolan.org/videolan/x264.git")
 lcb_external_source_paths("externals/x264")
 lcb_ignore_warnings(YES)
 
@@ -30,23 +29,46 @@ lcb_cross_compilation_options(
 	"--prefix=${CMAKE_INSTALL_PREFIX}"
 	"--host=${LINPHONE_BUILDER_HOST}"
 )
-lcb_configure_options(
+
+if(IOS)
+	lcb_configure_options(
 	"--extra-cflags=$CFLAGS"
 	"--extra-ldflags=$LDFLAGS"
-)
-if(IOS)
-	lcb_configure_options("--sysroot=${CMAKE_OSX_SYSROOT}")
+	"--sysroot=${CMAKE_OSX_SYSROOT}"
+	)
 	string(REGEX MATCH "^(arm*|aarch64)" ARM_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
 	if(ARM_ARCH AND NOT ${XCODE_VERSION} VERSION_LESS 7)
 		lcb_configure_options("--extra-asflags=-fembed-bitcode")
 	endif()
 elseif(ANDROID)
-	lcb_configure_options("--sysroot=${CMAKE_SYSROOT}")
-	if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-		set(X264_HOST "arm-none-linux-gnueabi")
+	lcb_configure_options(
+		"--disable-asm"
+		"--sysroot=${CMAKE_SYSROOT}"
+	)
+
+	if(CMAKE_ANDROID_NDK_VERSION VERSION_LESS 19 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
+		set(ANDROID_PLATFORM_LEVEL "17")
+		set(ANDROID_PLATFORM "android-17")
+		set(CMAKE_ANDROID_API "17")
+		set(NDK_TOOLCHAIN_VERSION "gcc")
 	else()
-		set(X264_HOST "i686-linux-gnueabi")
+		set(ANDROID_PLATFORM_LEVEL "21")
+		set(ANDROID_PLATFORM "android-21")
+		set(CMAKE_ANDROID_API "21")
+		set(NDK_TOOLCHAIN_VERSION "clang")
 	endif()
+
+	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
+		set(X264_HOST "arm-linux")
+	elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+		set(X264_HOST "aarch64-linux")
+	elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+		set(X264_HOST "x86_64-linux")
+	else()
+		set(X264_HOST "i686-linux")
+	endif()
+
+	message(STATUS "---------------------PREFIX '${CMAKE_ANDROID_NDK}'  '${ANDROID_HOST_TAG}' $CC")
 	lcb_cross_compilation_options(
 		"--prefix=${CMAKE_INSTALL_PREFIX}"
 		"--host=${X264_HOST}"
@@ -58,6 +80,10 @@ lcb_linking_type("--enable-shared")
 if(IOS)
 	lcb_configure_env("CC=\"$CC -arch ${LINPHONE_BUILDER_OSX_ARCHITECTURES}\"")
 else()
-	lcb_configure_env("CC=$CC")
+	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
+		lcb_configure_env("CC=${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_HOST_TAG}/bin/armv7a-linux-androideabi${CMAKE_ANDROID_API}-clang")
+	else()
+		lcb_configure_env("CC=${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_HOST_TAG}/bin/${CMAKE_SYSTEM_PROCESSOR}-linux-android${CMAKE_ANDROID_API}-clang")
+	endif()
 endif()
 lcb_install_target("install-lib-shared")


### PR DESCRIPTION
Hi,
with this PR (initially developed by Media Magic Technologies, updated by Divus GmbH) and the PR for **mediastreamer2** and **linphone-sdk** we have updated the version of **ffmpeg**, so that newer versions of the codecs can be used, improving the functionality especially on Android systems.

You also need to update the pointed **ffmpeg** submodule, so that it includes the release 4.4.2